### PR TITLE
Filter out unsupported file formats/extensions

### DIFF
--- a/cmd/internal/menu.go
+++ b/cmd/internal/menu.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/spf13/viper"
 
@@ -92,4 +93,22 @@ func Menu() {
 		}
 		ui.Render(l)
 	}
+}
+
+// Returns true if filename is a supported format
+func isAudioFile(filename string) bool {
+	// convert filename to lowercase to include uppercase extensions (i.e. "filename.MP3")
+	filename = strings.ToLower(filename)
+
+	// the audio playback package supports the formats below, but lunar currently only supports mp3.
+	// replace the last line in this function with the following 6 lines to include all formats.
+
+	// for _, ext := range []string{".wav", ".mp3", ".ogg", ".flac"} {
+	// 	if strings.HasSuffix(filename, ext) {
+	// 		return true
+	// 	}
+	// }
+	// return false
+
+	return strings.HasSuffix(filename, ".mp3")
 }

--- a/cmd/internal/menu.go
+++ b/cmd/internal/menu.go
@@ -42,7 +42,12 @@ func Menu() {
 
 	// Get file names in folder
 	for _, f := range filepath {
-		files = append(files, f.Name())
+		// Only include supported audio formats/extensions (currently only .mp3).
+		// Note that this has a side-effect of also filtering out directories, which need to be
+		// handled separately and navigated to instead of.. well.. crashing the application  =P
+		if isAudioFile(f.Name()) {
+			files = append(files, f.Name())
+		}
 	}
 
 	if err := ui.Init(); err != nil {


### PR DESCRIPTION
This PR implements the new function `isAudioFile()`, which returns whether the provided filename is a supported audio file and utilizes this function for filtering out unsupported file extensions from the file menu.

As noted both in the code comments and commit descriptions, lunar currently only supports `.mp3` files, despite the [beep](https://github.com/faiface/beep) library also supporting `.wav`, `.ogg` and `.flac`.

I've left an optional (commented) code within the function which should include all the formats mentioned above, if lunar ever gets updated to support them.

A few important notes:
- As a side-effect of this filtering, directories are also filtered out (which is good because they currently crash the program =P)
- The file name is checked as lowercase so uppercase extensions (i.e. `song.MP3`) work as expected.

### Comparison

Before
![image](https://user-images.githubusercontent.com/75134774/199643234-3d30dbca-f769-4732-8e40-7856dca248e1.png)

After
![image](https://user-images.githubusercontent.com/75134774/199643275-89701966-0814-478c-827c-fc60a333eb95.png)
